### PR TITLE
Avoid use of `datetime.utc*` deprecated in Python 3.12

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v5.3.0
+======
+
+#24: Removed use of ``datetime.utc**`` functions
+deprecated in Python 3.12.
+
 v5.2.2
 ======
 

--- a/tempora/schedule.py
+++ b/tempora/schedule.py
@@ -28,7 +28,7 @@ def now():
     A client may override this function to change the default behavior,
     such as to use local time or timezone-naïve times.
     """
-    return datetime.datetime.utcnow().replace(tzinfo=pytz.utc)
+    return datetime.datetime.now(pytz.utc)
 
 
 def from_timestamp(ts):
@@ -38,7 +38,7 @@ def from_timestamp(ts):
     A client may override this function to change the default behavior,
     such as to use local time or timezone-naïve times.
     """
-    return datetime.datetime.utcfromtimestamp(ts).replace(tzinfo=pytz.utc)
+    return datetime.datetime.fromtimestamp(ts, pytz.utc)
 
 
 class DelayedCommand(datetime.datetime):

--- a/tempora/timing.py
+++ b/tempora/timing.py
@@ -51,16 +51,21 @@ class Stopwatch:
             del self.start_time
 
     def start(self):
-        self.start_time = datetime.datetime.utcnow()
+        self.start_time = datetime.datetime.now(datetime.timezone.utc).replace(
+            tzinfo=None
+        )
 
     def stop(self):
-        stop_time = datetime.datetime.utcnow()
+        stop_time = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         self.elapsed += stop_time - self.start_time
         del self.start_time
         return self.elapsed
 
     def split(self):
-        local_duration = datetime.datetime.utcnow() - self.start_time
+        local_duration = (
+            datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+            - self.start_time
+        )
         return self.elapsed + local_duration
 
     # context manager support

--- a/tempora/timing.py
+++ b/tempora/timing.py
@@ -51,21 +51,16 @@ class Stopwatch:
             del self.start_time
 
     def start(self):
-        self.start_time = datetime.datetime.now(datetime.timezone.utc).replace(
-            tzinfo=None
-        )
+        self.start_time = datetime.datetime.now(datetime.timezone.utc)
 
     def stop(self):
-        stop_time = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        stop_time = datetime.datetime.now(datetime.timezone.utc)
         self.elapsed += stop_time - self.start_time
         del self.start_time
         return self.elapsed
 
     def split(self):
-        local_duration = (
-            datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
-            - self.start_time
-        )
+        local_duration = datetime.datetime.now(datetime.timezone.utc) - self.start_time
         return self.elapsed + local_duration
 
     # context manager support

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -132,7 +132,7 @@ class TestScheduler:
         sched = schedule.InvokeScheduler()
         target = mock.MagicMock()
 
-        before = datetime.datetime.now()
+        before = datetime.datetime.now(tz=datetime.timezone.utc)
 
         cmd = schedule.PeriodicCommand.after(10, target)
         sched.add(cmd)

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -132,7 +132,7 @@ class TestScheduler:
         sched = schedule.InvokeScheduler()
         target = mock.MagicMock()
 
-        before = datetime.datetime.utcnow()
+        before = datetime.datetime.now()
 
         cmd = schedule.PeriodicCommand.after(10, target)
         sched.add(cmd)


### PR DESCRIPTION
- https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcfromtimestamp
- https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcnow